### PR TITLE
thrift 0.16.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
   host:
     - pip
     - python
@@ -26,6 +27,8 @@ requirements:
   run:
     - python
     - six >=1.7.2
+  run_constrained:
+    - tornado >=4.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,5 @@
-{% set version = "0.16.0" %}
-{% set hash_type = "sha256" %}
-{% set hash = "df2931de646a366c2e5962af679018bca2395d586e00ba82d09c0379f14f8e7b" %}
 {% set name = "thrift" %}
+{% set version = "0.16.0" %}
 
 package:
   name: {{ name }}
@@ -9,7 +7,7 @@ package:
 
 source:
   url: https://github.com/apache/thrift/archive/refs/tags/v{{ version }}.tar.gz
-  {{ hash_type }}: {{ hash }}
+  sha256: df2931de646a366c2e5962af679018bca2395d586e00ba82d09c0379f14f8e7b
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: df2931de646a366c2e5962af679018bca2395d586e00ba82d09c0379f14f8e7b
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install ./lib/py -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,8 +52,7 @@ about:
     Thrift provides clean abstractions and implementations for data transport, data serialization, and application level processing.
   summary: Python bindings for the Apache Thrift RPC system
   dev_url: https://github.com/apache/thrift
-  doc_url: https://thrift.apache.org/docs/
-  doc_source_url: https://github.com/apache/thrift/tree/v{{ version }}/doc
+  doc_url: https://thrift.apache.org/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install ./lib/py -vv
+  script: {{ PYTHON }} -m pip install ./lib/py --no-deps --no-build-isolation -vv
 
 requirements:
   build:
@@ -47,7 +47,6 @@ about:
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE
-  license_url: https://github.com/apache/thrift/blob/master/LICENSE
   description: |
     Thrift is a lightweight, language-independent software stack for point-to-point RPC implementation.
     Thrift provides clean abstractions and implementations for data transport, data serialization, and application level processing.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ test:
     - pip
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
 
 about:
   home: https://thrift.apache.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "0.17.0" %}
+{% set version = "0.16.0" %}
 {% set hash_type = "sha256" %}
-{% set hash = "f5888bcd3b8de40c2c2ab86896867ad9b18510deb412cba3e5da76fb4c604c29" %}
+{% set hash = "df2931de646a366c2e5962af679018bca2395d586e00ba82d09c0379f14f8e7b" %}
 {% set name = "thrift" %}
 
 package:


### PR DESCRIPTION
thrift 0.16.0 

**Destination channel:** Defaults

### Links

- [PKG-9330]
- dev_url:        https://github.com/apache/thrift/tree/v0.16.0
- conda_forge:    https://github.com/conda-forge/thrift-feedstock
- pypi:           https://pypi.org/project/thrift/0.16.0
- pypi inspector: https://inspector.pypi.io/project/thrift/0.16.0

### Explanation of changes:

- new version number


[PKG-9330]: https://anaconda.atlassian.net/browse/PKG-9330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ