### PR TITLE
thrift 0.16 (py314 rebuild)

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,0 @@
-aggregate_check: false

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,18 +6,18 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/apache/thrift/archive/refs/tags/v{{ version }}.tar.gz
+  url: https://github.com/apache/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: df2931de646a366c2e5962af679018bca2395d586e00ba82d09c0379f14f8e7b
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install ./lib/py --no-deps --no-build-isolation -vv
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - {{ stdlib('c') }}
   host:
     - pip
     - python


### PR DESCRIPTION
thrift 0.16 314

**Destination channel:** defaults

### Links

- [PKG-15209](https://anaconda.atlassian.net/browse/PKG-15209) 

### Explanation of changes:

- Rebuild for py314


[PKG-15209]: https://anaconda.atlassian.net/browse/PKG-15209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ