### PR TITLE
update to 0.24.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "thrift" %}
-{% set version = "0.23.0" %}
+{% set version = "0.24.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5f43448a92c36ed6a450048355d10e231a1787e4c28965f08fabac0eb978914c
+  sha256: 9ef601c49e988475ff0e741d8e1b45feec23b48514e524341efc274191f1789c
 
 build:
   number: 0
@@ -21,11 +21,13 @@ requirements:
     - pip
     - python
     - wheel
-    - setuptools
+    - setuptools >=61.0
   run:
     - python
   run_constrained:
-    - tornado >=4.0
+    - tornado >=6.3.0
+    - twisted >=24.3.0
+    - zope.interface >=6.1
 
 # Tests disabled.
 # E   ModuleNotFoundError: No module named '_import_local_thrift'


### PR DESCRIPTION
thrift 0.24.0

**Destination channel:** defaults

### Links
- [PKG-16987](https://anaconda.atlassian.net/browse/PKG-16987)
- [GitHub release v0.24.0](https://github.com/apache/thrift/releases/tag/v0.24.0)
- [PyPI](https://pypi.org/project/thrift/0.24.0/)

### Explanation of changes:
- Updated thrift from 0.23.0 to 0.24.0 — upstream security-hardening release (see the [Apache advisory thread](https://lists.apache.org/thread/xjs36m6kjxpmrmzwck636msg3nvoqnmx)); no API/ABI breaks
- `run_constrained`: raised `tornado` to `>=6.3.0` and added `twisted >=24.3.0` + `zope.interface >=6.1`, matching the bounds upstream declares for its `tornado`/`twisted` extras in `setup.py`
- `host`: `setuptools >=61.0` per upstream `pyproject.toml` `[build-system].requires`
- Removed `abs.yaml`: its only entry was `ANACONDA_ROCKET_ENABLE_PY313`

[PKG-16987]: https://anaconda.atlassian.net/browse/PKG-16987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ